### PR TITLE
Refactor pdfPageViewer UI

### DIFF
--- a/lib/pdf_master.dart
+++ b/lib/pdf_master.dart
@@ -1,10 +1,13 @@
 export 'package:pdf_master/src/pdf/pdf_item_view.dart' show PdfItemView, PdfCoverView;
-export 'package:pdf_master/src/pdf/pdf_viewer_page.dart' show PDFViewerPage;
+export 'package:pdf_master/src/pdf/pdf_viewer_page.dart';
 
 export 'package:pdf_master/src/component/alert_dialog.dart';
 export 'package:pdf_master/src/component/page_router.dart';
 export 'package:pdf_master/src/component/app_bar.dart';
 export 'package:pdf_master/src/pdf/features/features.dart' show AdvancedFeature;
+export 'package:pdf_master/src/pdf/handlers/gesture_handler.dart';
+export 'package:pdf_master/src/component/bottom_bar.dart';
+export 'package:pdf_master/src/core/pdf_controller.dart' show PdfController, PdfOpenState;
 
 import 'dart:convert';
 import 'dart:ui' as ui;

--- a/lib/src/component/bottom_bar.dart
+++ b/lib/src/component/bottom_bar.dart
@@ -40,20 +40,17 @@ enum ToolAction {
   }
 }
 
-class BottomToolbar extends StatelessWidget {
-  final bool pageMode;
-  final ValueChanged<ToolAction> onToolAction;
+class ToolActions{
   final List<AdvancedFeature> features;
+  final ValueChanged<ToolAction> onToolAction;
+  const ToolActions({required this.features, required this.onToolAction});
 
-  const BottomToolbar({super.key, required this.pageMode, required this.onToolAction, required this.features});
-
-  Color? getIconColor(ToolAction action) {
+  Color? getIconColor(ToolAction action, bool pageMode) {
     if (action == ToolAction.kPageMode && pageMode) {
       return Colors.blue;
     }
     return null;
   }
-
   List<ToolAction> getToolActions() {
     final actions = [ToolAction.kToc, ToolAction.kRotate, ToolAction.kPageMode, ToolAction.kSearch];
     if (features.isNotEmpty) {
@@ -61,10 +58,15 @@ class BottomToolbar extends StatelessWidget {
     }
     return actions;
   }
+}
 
+class BottomToolbar extends StatelessWidget {
+  final bool pageMode;
+  final ToolActions toolActions;
+  const BottomToolbar({super.key, required this.pageMode, required this.toolActions});
   @override
   Widget build(BuildContext context) {
-    final actions = getToolActions();
+    final actions = toolActions.getToolActions();
     return Container(
       decoration: BoxDecoration(
         color: context.pdfTheme.appBarBackgroundColor,
@@ -79,8 +81,8 @@ class BottomToolbar extends StatelessWidget {
           children: List.generate(
             actions.length,
             (index) => IconButton(
-              onPressed: () => onToolAction(actions[index]),
-              icon: Icon(actions[index]._icon(), color: getIconColor(actions[index])),
+              onPressed: () => toolActions.onToolAction(actions[index]),
+              icon: Icon(actions[index]._icon(), color: toolActions.getIconColor(actions[index], pageMode)),
               tooltip: actions[index]._title(context),
             ),
           ),

--- a/lib/src/pdf/pdf_viewer_page.dart
+++ b/lib/src/pdf/pdf_viewer_page.dart
@@ -387,6 +387,7 @@ class _PDFViewerPageInternalState extends State<_PDFViewerPageInternal> {
   void initState() {
     super.initState();
     PdfMaster.instance.darkModeNotifier.addListener(_onDarkModeChanged);
+    widget.controller.editStateNotifier.addListener(_toggleBarVisible);
     SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]);
     toolActions = ToolActions(
       features: widget.features, 

--- a/lib/src/pdf/pdf_viewer_page.dart
+++ b/lib/src/pdf/pdf_viewer_page.dart
@@ -76,7 +76,7 @@ class _PDFViewerPageState extends State<PDFViewerPage> {
 class PDFLogicHelper {
   static Future<bool> saveEditBeforeAction(BuildContext context, PdfController controller) async {
     if (controller.editStateNotifier.value != PdfEditState.kEdit) {
-      return true;
+      return true; 
     }
 
     final ret = await showPdfMasterAlertDialog(

--- a/lib/src/pdf/pdf_viewer_page.dart
+++ b/lib/src/pdf/pdf_viewer_page.dart
@@ -5,7 +5,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:path/path.dart' as p;
 import 'package:pdf_master/pdf_master.dart';
-import 'package:pdf_master/src/component/bottom_bar.dart';
 import 'package:zoom_view/zoom_view.dart';
 
 import 'package:pdf_master/src/core/pdf_controller.dart';
@@ -14,7 +13,6 @@ import 'package:pdf_master/src/pdf/features/convert_image.dart';
 import 'package:pdf_master/src/pdf/features/features.dart';
 import 'package:pdf_master/src/pdf/features/image_extract.dart';
 import 'package:pdf_master/src/pdf/features/page_manage.dart';
-import 'package:pdf_master/src/pdf/handlers/gesture_handler.dart';
 import 'package:pdf_master/src/pdf/pdf_view_core.dart';
 import 'package:pdf_master/src/pdf/search/widgets.dart';
 import 'package:pdf_master/src/pdf/toc/toc.dart';
@@ -50,36 +48,324 @@ class PDFViewerPage extends StatefulWidget {
   State<PDFViewerPage> createState() => _PDFViewerPageState();
 }
 
-class FullScreenExitButton extends StatelessWidget {
-  final VoidCallback onTap;
-
-  const FullScreenExitButton({super.key, required this.onTap});
-
+class _PDFViewerPageState extends State<PDFViewerPage> {
   @override
   Widget build(BuildContext context) {
-    final top = MediaQuery.viewPaddingOf(context).top;
-    final right = MediaQuery.viewPaddingOf(context).right;
-    return Positioned(
-      top: top,
-      right: right,
-      child: Container(
-        margin: EdgeInsets.only(right: right > 24 ? 0 : max(24 - right, 0), top: top > 24 ? 0 : max(24 - top, 0)),
-        width: 48,
-        height: 48,
-        decoration: BoxDecoration(color: Colors.black.withAlpha(128), borderRadius: BorderRadius.circular(24)),
-        child: IconButton(
-          onPressed: onTap,
-          icon: Icon(Icons.close, color: Colors.white, size: 28),
-        ),
-      ),
+    return PdfDocumentLoader(
+        filePath: widget.filePath,
+        password: widget.password,
+        builder: (context, controller) {
+          return _PDFViewerPageInternal(
+            key: widget.key,
+            filePath: widget.filePath,
+            password: widget.password,
+            pageMode: widget.pageMode,
+            fullScreen: widget.fullScreen,
+            enableEdit: widget.enableEdit,
+            showTitleBar: widget.showTitleBar,
+            showToolBar: widget.showToolBar,
+            doubleTapDragZoom: widget.doubleTapDragZoom,
+            controller: controller,
+            features: widget.features,
+          );
+        },
     );
   }
 }
 
-class _PDFViewerPageState extends State<PDFViewerPage> {
+class PDFLogicHelper {
+  static Future<bool> saveEditBeforeAction(BuildContext context, PdfController controller) async {
+    if (controller.editStateNotifier.value != PdfEditState.kEdit) {
+      return true;
+    }
+
+    final ret = await showPdfMasterAlertDialog(
+      context,
+      context.localizations['warning'],
+      context.localizations['save'],
+      content: context.localizations['editNotSave'],
+      negativeButtonText: context.localizations['cancel'],
+    );
+
+    if (ret == true) {
+      await controller.save();
+      controller.editStateNotifier.value = PdfEditState.kNone;
+      return true;
+    }
+    return false;
+  }
+
+  static void setSystemFullScreen(bool fullScreen) {
+    if (fullScreen) {
+      SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
+      SystemChrome.setPreferredOrientations([DeviceOrientation.landscapeLeft, DeviceOrientation.landscapeRight]);
+    } else {
+      SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
+      SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]);
+    }
+  }
+
+  static void onShareAction(String filePath) {
+    PdfMaster.instance.shareHandler?.handleSharePdfFile(filePath);
+  }
+
+  static Future<String?> onFeatureAction(BuildContext context, PdfController controller, AdvancedFeature action) async {
+    if (!context.mounted) return null;
+
+    switch (action) {
+      case AdvancedFeature.kPageManage:
+        final newFilePath = await Navigator.of(context)
+            .push<String>(PDFMasterPageRouter(builder: (ctx) => PageManagePage(controller: controller)));
+        return newFilePath;
+      case AdvancedFeature.kConvertImage:
+        Navigator.push(context, PDFMasterPageRouter(builder: (ctx) => PageSelector(controller: controller)));
+        break;
+      case AdvancedFeature.kImageExtract:
+        Navigator.push(context, PDFMasterPageRouter(builder: (ctx) => ImageExtractPage(controller: controller)));
+        break;
+    }
+    return null;
+  }
+
+  static void onFeatureSelected(AdvancedFeature feature, BuildContext context, PdfController controller) async {
+    final newPath = await PDFLogicHelper.onFeatureAction(context, controller, feature);
+    if (newPath != null && context.mounted) {
+      Navigator.pop(context, newPath);
+    }
+  }
+
+  static void onToolAction(
+    BuildContext context,
+    PdfController controller,
+    ToolAction action, {
+    required VoidCallback onTogglePageMode,
+    required VoidCallback onRotate,
+    required Function(AdvancedFeature) onFeatureSelected,
+  }) async {
+    switch (action) {
+      case ToolAction.kToc:
+        showTocBottomSheet(context, controller, controller.tocState);
+        break;
+      case ToolAction.kSearch:
+        if (await saveEditBeforeAction(context, controller)) {
+          controller.editStateNotifier.value = PdfEditState.kSearch;
+        }
+        break;
+      case ToolAction.kPageMode:
+        if (await saveEditBeforeAction(context, controller)) {
+          onTogglePageMode();
+        }
+        break;
+      case ToolAction.kMore:
+        showFeatureMenus(context, controller, AdvancedFeature.values, (feature) async {
+          if (!await saveEditBeforeAction(context, controller)) return;
+          onFeatureSelected(feature);
+        });
+        break;
+      case ToolAction.kRotate:
+        onRotate();
+        break;
+    }
+  }
+}
+
+class PdfDocumentLoader extends StatefulWidget {
+  final String filePath;
+  final String password;
+  final Widget Function(BuildContext context, PdfController controller) builder;
+  final Widget Function(BuildContext context)? loadingBuilder;
+
+  const PdfDocumentLoader({
+    super.key,
+    required this.filePath,
+    required this.builder,
+    this.password = "",
+    this.loadingBuilder,
+  });
+
+  @override
+  State<PdfDocumentLoader> createState() => _PdfDocumentLoaderState();
+}
+
+class _PdfDocumentLoaderState extends State<PdfDocumentLoader> {
+  late PdfController controller;
+  bool _isError = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _openDocument(widget.password);
+  }
+
+  @override
+  void dispose() {
+    controller.dispose();
+    super.dispose();
+  }
+
+  void _openDocument(String password) async {
+    controller = PdfController(widget.filePath, password: password);
+    await controller.open();
+
+    if (!mounted) return;
+
+    if (controller.opened) {
+      setState(() {});
+    } else if (controller.needPassword) {
+      final input = await showPdfMasterInputDialog(
+        context,
+        context.localizations[controller.password.isEmpty ? "needPassword" : "passwordErr"],
+        context.localizations["inputPassword"],
+      );
+      if (input == null) {
+        if (mounted) Navigator.pop(context);
+      } else {
+        await controller.dispose();
+        _openDocument(input);
+      }
+    } else {
+      setState(() => _isError = true);
+      await showPdfMasterAlertDialog(context, context.localizations["fmtErr"], context.localizations['ok']);
+      if (mounted) Navigator.pop(context);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_isError) return const SizedBox.shrink();
+
+    if (!controller.opened) {
+      return widget.loadingBuilder?.call(context) ??
+          const Scaffold(body: Center(child: CircularProgressIndicator()));
+    }
+
+    return widget.builder(context, controller);
+  }
+}
+
+class PdfAppBar extends StatelessWidget {
+  final PdfController controller;
+  final String title;
+  final bool isFullScreen;
+  final bool showTitleBar;
+  final VoidCallback? onBackPressed;
+  final VoidCallback? onSharePressed;
+
+  const PdfAppBar({
+    super.key,
+    required this.controller,
+    required this.title,
+    this.isFullScreen = false,
+    this.showTitleBar = true,
+    this.onBackPressed,
+    this.onSharePressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<PdfEditState>(
+      valueListenable: controller.editStateNotifier,
+      builder: (context, editMode, child) {
+        if (isFullScreen || !showTitleBar) return const SizedBox.shrink();
+        switch (editMode) {
+          case PdfEditState.kNone:
+            return PdfMasterAppBar(
+              title: title,
+              leading: IconButton(
+                onPressed: onBackPressed ?? () => Navigator.pop(context),
+                icon: const Icon(Icons.arrow_back),
+              ),
+              action: Visibility(
+                visible: PdfMaster.instance.shareHandler != null,
+                child: IconButton(
+                  onPressed: onSharePressed ?? () => PDFLogicHelper.onShareAction(controller.path),
+                  icon: const Icon(Icons.ios_share),
+                ),
+              ),
+            );
+          case PdfEditState.kEdit:
+            return EditToolBar(controller: controller);
+          case PdfEditState.kSearch:
+            return SearchToolBar(controller: controller, searchState: controller.searchState);
+        }
+      },
+    );
+  }
+}
+
+class PdfBottomBar extends StatelessWidget {
+  final PdfController controller;
+  final bool pageMode;
+  final bool isFullScreen;
+  final bool showToolBar;
+  final ToolActions toolActions;
+
+  const PdfBottomBar({
+    super.key,
+    required this.controller,
+    required this.pageMode,
+    this.isFullScreen = false,
+    this.showToolBar = true, 
+    required this.toolActions,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<PdfEditState>(
+      valueListenable: controller.editStateNotifier,
+      builder: (context, editMode, child) {
+        if (isFullScreen || !showToolBar) return const SizedBox.shrink();
+
+        switch (editMode) {
+          case PdfEditState.kEdit:
+          case PdfEditState.kNone:
+            return BottomToolbar(
+              pageMode: pageMode,
+              toolActions: toolActions,
+              
+            );
+          case PdfEditState.kSearch:
+            return SearchBottomBar(controller: controller, searchState: controller.searchState);
+        }
+      },
+    );
+  }
+}
+
+class _PDFViewerPageInternal extends StatefulWidget {
+  final String filePath;
+  final String password;
+  final bool pageMode;
+  final bool fullScreen;
+  final bool enableEdit;
+  final bool showTitleBar;
+  final bool showToolBar;
+  final bool doubleTapDragZoom;
+  final List<AdvancedFeature> features;
+  final PdfController controller;
+
+  const _PDFViewerPageInternal({
+    super.key,
+    required this.filePath,
+    this.password = "",
+    this.pageMode = false,
+    this.fullScreen = false,
+    this.enableEdit = true,
+    this.showTitleBar = true,
+    this.showToolBar = true,
+    this.doubleTapDragZoom = false,
+    this.features = AdvancedFeature.values, 
+    required this.controller,
+  });
+
+  @override
+  State<_PDFViewerPageInternal> createState() => _PDFViewerPageInternalState();
+}
+
+class _PDFViewerPageInternalState extends State<_PDFViewerPageInternal> {
+  late ToolActions toolActions;
   late bool pageMode = widget.pageMode;
   late bool fullscreen = widget.fullScreen;
-  late PdfController controller;
   final containerKey = GlobalKey();
   final appBarKey = GlobalKey();
   final bottomBarKey = GlobalKey();
@@ -101,42 +387,31 @@ class _PDFViewerPageState extends State<PDFViewerPage> {
   @override
   void initState() {
     super.initState();
-    _openDocument(widget.password);
     PdfMaster.instance.darkModeNotifier.addListener(_onDarkModeChanged);
     SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]);
+    toolActions = ToolActions(
+      features: widget.features, 
+      onToolAction: (action) {
+        PDFLogicHelper.onToolAction(
+          context,
+          widget.controller,
+          action,
+          onTogglePageMode: () => setState(() => pageMode = !pageMode),
+          onRotate: () => _changeFullScreenMode(true),
+          onFeatureSelected: (feature) async {
+            PDFLogicHelper.onFeatureSelected(feature, context, widget.controller);
+          },
+        );
+      },
+    );
   }
 
   @override
   void dispose() {
-    super.dispose();
-    controller.dispose();
     SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
     PdfMaster.instance.darkModeNotifier.removeListener(_onDarkModeChanged);
     SystemChrome.setPreferredOrientations([]);
-  }
-
-  void _openDocument(String password) async {
-    controller = PdfController(widget.filePath, password: password);
-    await controller.open();
-    if (!mounted) return;
-    if (controller.opened) {
-      setState(() {});
-    } else if (controller.needPassword) {
-      final input = await showPdfMasterInputDialog(
-        context,
-        context.localizations[controller.password.isEmpty ? "needPassword" : "passwordErr"],
-        context.localizations["inputPassword"],
-      );
-      if (input == null) {
-        if (mounted) Navigator.pop(context);
-      } else {
-        await controller.dispose();
-        _openDocument(input);
-      }
-    } else {
-      await showPdfMasterAlertDialog(context, context.localizations["fmtErr"], context.localizations['ok']);
-      if (mounted) Navigator.pop(context);
-    }
+    super.dispose();
   }
 
   void _onDarkModeChanged() {
@@ -147,8 +422,13 @@ class _PDFViewerPageState extends State<PDFViewerPage> {
     setState(() => _barsVisible = visible ?? !_barsVisible);
   }
 
+  void _changeFullScreenMode(bool isFullScreen) {
+    setState(() => fullscreen = isFullScreen);
+    PDFLogicHelper.setSystemFullScreen(isFullScreen);
+  }
+
   Widget _buildContent(_, BoxConstraints constraints) {
-    switch (controller.openState) {
+    switch (widget.controller.openState) {
       case PdfOpenState.kFmtError:
       case PdfOpenState.kUnknownError:
       case PdfOpenState.kNone:
@@ -161,7 +441,7 @@ class _PDFViewerPageState extends State<PDFViewerPage> {
           visible: pageMode,
           replacement: PdfListViewer(
             key: ValueKey(MediaQuery.orientationOf(context)),
-            controller: controller,
+            controller: widget.controller,
             constraints: BoxConstraints(maxWidth: constraints.maxWidth, maxHeight: constraints.maxHeight),
             padding: EdgeInsets.only(top: appBarHeight, bottom: bottomBarHeight),
             containerKey: containerKey,
@@ -172,7 +452,7 @@ class _PDFViewerPageState extends State<PDFViewerPage> {
           ),
           child: PdfPageViewer(
             key: ValueKey(MediaQuery.orientationOf(context)),
-            controller: controller,
+            controller: widget.controller,
             constraints: BoxConstraints(maxWidth: constraints.maxWidth, maxHeight: constraints.maxHeight),
             padding: EdgeInsets.only(top: appBarHeight, bottom: bottomBarHeight),
             containerKey: containerKey,
@@ -208,8 +488,6 @@ class _PDFViewerPageState extends State<PDFViewerPage> {
         child: Stack(
           children: [
             Positioned.fill(
-              top: 0,
-              bottom: 0,
               child: GestureDetector(
                 onTap: _toggleBarVisible,
                 child: LayoutBuilder(builder: _buildContent),
@@ -221,7 +499,13 @@ class _PDFViewerPageState extends State<PDFViewerPage> {
               top: _barsVisible ? 0 : -(appBarHeight + MediaQuery.of(context).padding.top),
               left: 0,
               right: 0,
-              child: _appBar(),
+              child: PdfAppBar(
+                key: appBarKey,
+                controller: widget.controller,
+                title: p.basename(widget.filePath),
+                isFullScreen: fullscreen,
+                showTitleBar: widget.showTitleBar,
+              ),
             ),
 
             AnimatedPositioned(
@@ -230,13 +514,21 @@ class _PDFViewerPageState extends State<PDFViewerPage> {
               bottom: _barsVisible ? 0 : -(bottomBarHeight + MediaQuery.of(context).padding.bottom),
               left: 0,
               right: 0,
-              child: _bottomBar(),
+              child: PdfBottomBar(
+                key: bottomBarKey,
+                controller: widget.controller,
+                pageMode: pageMode,
+                isFullScreen: fullscreen,
+                showToolBar: widget.showToolBar,
+                toolActions: toolActions,
+              ),
             ),
 
-            if (fullscreen) FullScreenExitButton(onTap: () => _changeFullScreenMode(false)),
+            if (fullscreen)
+              FullScreenExitButton(onTap: () => _changeFullScreenMode(false)),
           ],
         ),
-      ),
+      )
     );
 
     return PopScope(
@@ -245,129 +537,33 @@ class _PDFViewerPageState extends State<PDFViewerPage> {
       child: body,
     );
   }
+}
 
-  Widget _appBar() {
-    return ValueListenableBuilder(
-      key: appBarKey,
-      valueListenable: controller.editStateNotifier,
-      builder: (context, editMode, child) {
-        if (fullscreen || !widget.showTitleBar) return SizedBox.shrink();
-        switch (editMode) {
-          case PdfEditState.kNone:
-            return PdfMasterAppBar(
-              title: p.basename(widget.filePath),
-              leading: IconButton(onPressed: () => Navigator.pop(context), icon: Icon(Icons.arrow_back)),
-              action: Visibility(
-                visible: PdfMaster.instance.shareHandler != null,
-                child: IconButton(onPressed: _onShareTapped, icon: Icon(Icons.ios_share)),
-              ),
-            );
-          case PdfEditState.kEdit:
-            return EditToolBar(controller: controller);
-          case PdfEditState.kSearch:
-            return SearchToolBar(controller: controller, searchState: controller.searchState);
-        }
-      },
+class FullScreenExitButton extends StatelessWidget {
+  final VoidCallback onTap;
+
+  const FullScreenExitButton({super.key, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final top = MediaQuery.viewPaddingOf(context).top;
+    final right = MediaQuery.viewPaddingOf(context).right;
+    return Positioned(
+      top: top,
+      right: right,
+      child: Container(
+        margin: EdgeInsets.only(
+            right: right > 24 ? 0 : max(24 - right, 0), top: top > 24 ? 0 : max(24 - top, 0)),
+        width: 48,
+        height: 48,
+        decoration: BoxDecoration(
+            color: Colors.black.withAlpha(128), borderRadius: BorderRadius.circular(24)),
+        child: IconButton(
+          onPressed: onTap,
+          icon: Icon(Icons.close, color: Colors.white, size: 28),
+        ),
+      ),
     );
-  }
-
-  Widget _bottomBar() {
-    return ValueListenableBuilder(
-      key: bottomBarKey,
-      valueListenable: controller.editStateNotifier,
-      builder: (context, editMode, child) {
-        if (fullscreen || !widget.showToolBar) return SizedBox.shrink();
-        switch (editMode) {
-          case PdfEditState.kEdit:
-          case PdfEditState.kNone:
-            return BottomToolbar(pageMode: pageMode, onToolAction: _onToolAction, features: widget.features);
-          case PdfEditState.kSearch:
-            return SearchBottomBar(controller: controller, searchState: controller.searchState);
-        }
-      },
-    );
-  }
-
-  Future<bool> _saveEditBeforeJump() async {
-    if (controller.editStateNotifier.value != PdfEditState.kEdit) {
-      return true;
-    }
-
-    final ret = await showPdfMasterAlertDialog(
-      context,
-      context.localizations['warning'],
-      context.localizations['save'],
-      content: context.localizations['editNotSave'],
-      negativeButtonText: context.localizations['cancel'],
-    );
-
-    if (ret == true) {
-      await controller.save();
-      controller.editStateNotifier.value = PdfEditState.kNone;
-      setState(() {});
-      return true;
-    }
-    return false;
-  }
-
-  void _changeFullScreenMode(bool fullscreen) {
-    this.fullscreen = fullscreen;
-    if (fullscreen) {
-      SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
-      SystemChrome.setPreferredOrientations([DeviceOrientation.landscapeLeft, DeviceOrientation.landscapeRight]);
-    } else {
-      SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
-      SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]);
-    }
-    setState(() {});
-  }
-
-  void _onToolAction(ToolAction action) async {
-    switch (action) {
-      case ToolAction.kToc:
-        showTocBottomSheet(context, controller, controller.tocState);
-        break;
-      case ToolAction.kSearch:
-        if (await _saveEditBeforeJump()) {
-          controller.editStateNotifier.value = PdfEditState.kSearch;
-        }
-        break;
-      case ToolAction.kPageMode:
-        if (await _saveEditBeforeJump()) {
-          setState(() => pageMode = !pageMode);
-        }
-        break;
-      case ToolAction.kMore:
-        showFeatureMenus(context, controller, widget.features, _onFeatureAction);
-        break;
-      case ToolAction.kRotate:
-        _changeFullScreenMode(true);
-        break;
-    }
-  }
-
-  void _onFeatureAction(AdvancedFeature action) async {
-    if (!await _saveEditBeforeJump()) return;
-    if (!mounted) return;
-    switch (action) {
-      case AdvancedFeature.kPageManage:
-        final newFilePath = await Navigator.of(
-          context,
-        ).push<String>(PDFMasterPageRouter(builder: (ctx) => PageManagePage(controller: controller)));
-        if (!mounted || newFilePath == null) return;
-        Navigator.pop(context, newFilePath);
-        break;
-      case AdvancedFeature.kConvertImage:
-        Navigator.push(context, PDFMasterPageRouter(builder: (ctx) => PageSelector(controller: controller)));
-        break;
-      case AdvancedFeature.kImageExtract:
-        Navigator.push(context, PDFMasterPageRouter(builder: (ctx) => ImageExtractPage(controller: controller)));
-        break;
-    }
-  }
-
-  void _onShareTapped() async {
-    PdfMaster.instance.shareHandler?.handleSharePdfFile(widget.filePath);
   }
 }
 


### PR DESCRIPTION
fixes #8 
Main changes: `PDFViewerPage` now calls `PdfDocumentLoader` and `_PDFViewerPageInternal` which now contains the logic of the original `PDFViewerPage`. This allows us to separate the document loading from the viewer, and also means `_PDFViewerPageInternal` is guaranteed to have a `PDFController` on `initState`.

Most of the logic of the tool actions has been moved to a helper class named `PDFLogicHelper`. Maybe `PDFActionHandler` would be a better name. This allows users to implement tool logic easily. The class is stateless and all methods are static so there should be no problem in passing the BuildContext to it. 

The `BottomToolbar` widget now take a  `ToolActions` class which calls the `onToolAction` callback. This means users can create their own `BottomToolbar` widget such as a transparent toolbar or different `boxDecoration` values.

This PR is just a suggestion, we can come up with a better solution if this isn't good. The main drawback is more of the API must now be exposed. This exposes `PdfOpenState` and `PdfBackgroundTapNotification`. If we provide a `PDFViewSwitcher` widget that switches between page and list then we don't need to expose `PdfOpenState`.
